### PR TITLE
Issue 5-7-8-17

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -22,10 +22,6 @@ There are some logical keys in `global_parameters.f90` that can be configured to
 
 * `use_only_integration`: if true, the program will just perform an integration (using Mercury6 package) and create .aei files without finding any resonances.
 * `just_id_matrices` will force the program only create files with id_matrices without finding any resonances and .aei files
-* `allow_writing_metadata` allows creating metadata files (usually for creating graphics following after that)
-* `allow_plotting` allows plotting graphics (works when creating metadata is allowed too)
-* `plot_all`"`: if plotting is allowed, all graphics for all cases (even circulations) will be drawn
-* `dispose_metadata` - delete metadata after using (because it can take a lot of disk memory
 * `force_aei_rebuilding`: if true, the integration will be performed even if corresponding .aei files already exist
 * `mode_2body`: turns on 2-body case
 * `mode_3body` turns on 3-body case

--- a/axis/resonant_axis.f90
+++ b/axis/resonant_axis.f90
@@ -63,17 +63,4 @@ contains
     end function count_axis_3body
 
 !----------------------------------------------------------------------------------------------
-    real(8) function a_from_n(n)
-    ! Get semimajor axis from mean motion
-    ! This function is left for support. It is not recommended to use it anymore.
-    ! Given:
-    !   n - mean motion of object
-    ! Returns:
-    !   <real(8)> - semimajor axis
-        real(8):: n
-
-        a_from_n = (gp_k/n)**(2d0/3d0)
-    end function a_from_n
-
-!----------------------------------------------------------------------------------------------
 end module resonant_axis

--- a/axis/resonant_axis.fun
+++ b/axis/resonant_axis.fun
@@ -2,20 +2,8 @@ test_suite resonant_axis
 
 real(8), parameter:: a_default = 1.00000261d0, k_default = 0.017202098795d0, n_default = 1.72020309d-02 
 
-test a_from_n_test
-    assert_equal_within(a_from_n(n_default), a_default, 1d-4)
-end test
-
 test n_from_a_test
     assert_equal_within(n_from_a(a_default), n_default, 1d-4)
-end test
-
-test n_from_a_reverse_test
-    real(8):: a, n
-    
-    n = n_from_a(a_default)
-    a = a_from_n(n)
-    assert_equal_within(a, a_default, 1d-4)
 end test
 
 test count_axis_2body_test


### PR DESCRIPTION
Removed unused function "a_from_n"
"n_from_a" is left in "global_parameters" since it is used in several modules.
Deleted unused branch "integrator/priority".
Removed old documentation references to unexisting parameters.